### PR TITLE
[feat] 루트 디테일 페이지 맵, 루트 마커 추가

### DIFF
--- a/src/main/java/com/tastehill/myweb/detail/DetailController.java
+++ b/src/main/java/com/tastehill/myweb/detail/DetailController.java
@@ -4,10 +4,14 @@ import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,6 +34,9 @@ import com.tastehill.myweb.route.RouteVO;
 
 @Controller
 public class DetailController {
+	
+	@Value("${google.map.apiKey}")
+	private String API_KEY;
 	
 	@Autowired
 	private MemberService msvc;
@@ -63,5 +70,41 @@ public class DetailController {
 		model.addAttribute("content", "jsp/detail/route_detail.jsp");
 		return "index";
 	}
+	
+	@RequestMapping(value = "/detail/{seqRoute}", method = RequestMethod.GET)
+	public String ctlDetailmapPage(HttpServletRequest request, Model model, 
+			@PathVariable("seqRoute") int seqRoute) {
+		
+		HttpSession session =  request.getSession();
+		//테스트용 멤버 1번
+		session.setAttribute("SESS_MEMBER_ID", 1);
+		session.setAttribute("API_KEY", API_KEY);
+		
+
+		MemberVO mvo = msvc.svcSelectMember(1);
+		
+		RouteVO rvo =  rsvc.svcSelectRoutesAndPlaceBySeqRoute(seqRoute);
+		
+		System.out.println(rvo.toString());
+//		List<CommentsVO> clist = csvc.svcSelectComments(1);
+//		model.addAttribute("MVO", mvo);
+//		model.addAttribute("CLIST", clist);
+		
+		model.addAttribute("seqRoute", seqRoute);
+		model.addAttribute("content", "jsp/detail/route_detail.jsp");
+		return "index";
+	}
+	
+	// 루트vo 전달
+	// 공통 기능이 될거같아서 route쪽으로 빼야 될까 고민중
+	@GetMapping("/detail/getRoute/{seqRoute}")
+    public ResponseEntity<RouteVO> getRouteDetail(@PathVariable int seqRoute) {
+		
+        RouteVO rvo = rsvc.svcSelectRoutesAndPlaceBySeqRoute(seqRoute);
+        if (rvo == null) {
+            return ResponseEntity.status(404).body(null); 
+        }
+        return ResponseEntity.ok(rvo); 
+    }
 		
 }

--- a/src/main/java/com/tastehill/myweb/place/PlaceVO.java
+++ b/src/main/java/com/tastehill/myweb/place/PlaceVO.java
@@ -23,4 +23,5 @@ public class PlaceVO {
     
 
     private PhotoVO photos;
+    private LocationVO location;
 }

--- a/src/main/resources/mapper/route-mapper.xml
+++ b/src/main/resources/mapper/route-mapper.xml
@@ -27,6 +27,12 @@
             <result property="name" column="name"/>
             <result property="formatted_address" column="formatted_address"/>
             <result property="rating" column="rating"/>
+            <association property="location" javaType="com.tastehill.myweb.place.LocationVO">
+	            <id property="seq_place" column="l_seq_place"/>
+	            <result property="place_id" column="l_place_id"/>
+	            <result property="lat" column="lat"/>
+	            <result property="lng" column="lng"/>
+        	</association>
         </association>
     </collection>
 </resultMap>
@@ -81,10 +87,12 @@ SELECT
     SELECT 
         r.seq_route, r.title, r.contents, r.seq_member, r.created_at, r.updated_at, r.fork_count,
         rp.seq_place AS rp_seq_place, rp.order_place, rp.price,
-        p.seq_place, p.place_id, p.name, p.formatted_address, p.rating
+        p.seq_place, p.place_id, p.name, p.formatted_address, p.rating,
+        l.seq_place as l_seq_place, l.place_id as l_place_id, l.lat, l.lng
     FROM route r
     LEFT JOIN route_place rp ON r.seq_route = rp.seq_route
     LEFT JOIN place p ON rp.seq_place = p.seq_place
+    LEFT JOIN location l ON l.seq_place = p.seq_place
     WHERE r.seq_route = #{seq_route}
     ORDER BY r.fork_count, rp.order_place
 </select>

--- a/src/main/webapp/jsp/detail/route_detail.jsp
+++ b/src/main/webapp/jsp/detail/route_detail.jsp
@@ -6,6 +6,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Post Detail</title>
+        <script src="https://maps.googleapis.com/maps/api/js?key=${sessionScope.API_KEY}&libraries=places"></script>
 	<link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/resources/css/route_detail.css">
 </head>
 <body>
@@ -13,6 +14,10 @@
         <!-- Map placeholder -->
         <div class="map-container">
             <!-- Map will be inserted here -->
+            <div id="map">
+            
+            
+            </div>
         </div>
 
         <!-- Post header -->
@@ -114,10 +119,77 @@ when an unknown printer took a galley of type and scrambled it to make a t
         </div>
     </div>
     
+    
     <script src="https://code.jquery.com/jquery-3.7.1.js"></script>
 <script>
+	let map;
+	let service;
+	let currentPolyline = null;
+	let res;
+
+function initMap(res) {
+	/* 루트VO 첫번째 장소 기준 플레이스 찍기 */
+	console.log(res.places[0].place.location.lat);
+    const center = { lat: res.places[0].place.location.lat, 
+    			     lng: res.places[0].place.location.lng };
+    map = new google.maps.Map(document.getElementById("map"), {
+        center: center,
+        zoom: 16,
+        styles: [
+            {
+                "featureType": "poi",
+                "elementType": "labels",
+                "stylers": [{ "visibility": "off" }]
+            },
+            {
+                "featureType": "landscape",
+                "elementType": "labels.icon",
+                "stylers": [{ "visibility": "off" }]
+            }
+        ]
+    });
+    service = new google.maps.places.PlacesService(map);
+}
+	
+function displayPlace(place) {
+/*   	console.log(place.location);
+	console.log(place.location); */ 
+ 
+ 	var myLatlng = new google.maps.LatLng(place.location.lat, place.location.lng);
+    const marker = new google.maps.Marker({
+        map: map,
+        position: myLatlng
+    });
+}
+
+function markingPlace(results) {
+        results.forEach(places => {
+        	/* const placeClone = JSON.parse(JSON.stringify(place)); */
+        	/* console.log(place); */
+        	displayPlace(places.place);
+        });
+}
+
 $( document ).ready(function() {
 	
+	/* 루트 정보 컨트롤러에 요청하는 부분 */
+	 $.ajax({
+	        url: "/detail/getRoute/" + ${seqRoute},
+	        method: "GET",
+	        dataType: "json",
+	        success: function(response) {
+	            /* console.log("경로 데이터:", response.places); */
+	            res = JSON.parse(JSON.stringify(response));
+	            /* console.log(res); */
+	            initMap(res);
+	            markingPlace(res.places);
+	        },
+	        error: function(error) {
+	            console.error("에러 발생:", error);
+	        }
+	    });
+	 
+	 
 	//$("#emp-btn").click( function() {
 		
 		/*
@@ -187,11 +259,9 @@ $( document ).ready(function() {
 	    });
 	});
 	
-	
+
 	
 });
-
-
 
 </script>
 </body>

--- a/src/main/webapp/jsp/route/google_map.jsp
+++ b/src/main/webapp/jsp/route/google_map.jsp
@@ -88,6 +88,21 @@
             infowindow = new google.maps.InfoWindow();
             service = new google.maps.places.PlacesService(map);
         }
+        
+        function requestRoute(){
+        	$.ajax({
+                url: "/detail/getRoute/" + seqRoute,
+                method: "GET",
+                dataType: "json",
+                success: function(response) {
+                    console.log("경로 데이터:", response);
+                    $(".post-title").text(response.routeName);  // 예제: 제목 변경
+                },
+                error: function(error) {
+                    console.error("에러 발생:", error);
+                }
+            });
+        }
 
         function searchPlaces() {
 /*             if (currentPolyline) {
@@ -106,6 +121,7 @@
         }
 
         function placesCallback(results, status) {
+        	console.log(results);
             if (status === google.maps.places.PlacesServiceStatus.OK) {
                 results.forEach(place => displayPlace(place));
             } else {
@@ -121,6 +137,7 @@
             
             marker.set('placeData', place);
             markers.push(marker);
+            console.log(markers);
             
             marker.addListener("click", ({ domEvent, latLng }) => {
                 const { target } = domEvent;

--- a/src/main/webapp/resources/css/route_detail.css
+++ b/src/main/webapp/resources/css/route_detail.css
@@ -5,11 +5,24 @@
 }
 
 /* Map container */
-.map-container {
+/* .map-container {
     width: 100%;
     height: 300px;
     background-color: #f0f0f0;
     margin-bottom: 20px;
+} */
+
+.map-container {
+    flex-grow: 1;
+    position: relative;
+    height: auto;
+    display: flex;
+    flex-direction: column;
+}
+
+#map {
+    width: 100%;
+    height: 400px;
 }
 
 /* Post header */

--- a/target/m2e-wtp/web-resources/META-INF/MANIFEST.MF
+++ b/target/m2e-wtp/web-resources/META-INF/MANIFEST.MF
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
-Built-By: JANG
+Built-By: Ho
 Build-Jdk: 11.0.22
 Created-By: Maven Integration for Eclipse
 


### PR DESCRIPTION
루트 디테일 페이지 맵, 루트 마커 추가

# Title
루트 디테일 페이지 맵, 루트 마커 추가


## 🔎 작업 내용

루트디테일 페이지 들어갈때 인자로 넣은 route에 잇는 placeVO들을 마커로 찍고
맵의 센터를 첫번째 placeVO의 위도, 경도로 설정합니다
## 이미지 첨부

![image](https://github.com/user-attachments/assets/881e11ca-13e4-4a6c-99bb-9e440a92edd8)

## ➕ 이슈 링크

- [레포 이름 #이슈번호]

<br/>
